### PR TITLE
add missing clr classes

### DIFF
--- a/system/modules/dk_caroufredsel/dca/tl_dk_caroufredsel.php
+++ b/system/modules/dk_caroufredsel/dca/tl_dk_caroufredsel.php
@@ -198,7 +198,7 @@ $GLOBALS['TL_DCA']['tl_dk_caroufredsel'] = array
 			'label'				=> &$GLOBALS['TL_LANG']['tl_dk_caroufredsel']['scrollItems'],
 			'exclude'			=> true,
 			'inputType'			=> 'text',
-			'eval'				=> array('maxlength' => 5, 'rgxp' => 'digit'),
+			'eval'				=> array('maxlength' => 5, 'rgxp' => 'digit', 'tl_class' => 'clr'),
 			'sql'				=> "smallint(5) unsigned NOT NULL default '0'"
 		),
 		'scrollQueue' => array
@@ -310,7 +310,7 @@ $GLOBALS['TL_DCA']['tl_dk_caroufredsel'] = array
 			'label'				=> &$GLOBALS['TL_LANG']['tl_dk_caroufredsel']['scrollDuration'],
 			'exclude'			=> true,
 			'inputType'			=> 'text',
-			'eval'				=> array('maxlength' => 10, 'rgxp' => 'digit'),
+			'eval'				=> array('maxlength' => 10, 'rgxp' => 'digit', 'tl_class' => 'clr'),
 			'sql'				=> "int(10) NOT NULL default '500'"
 		),
 


### PR DESCRIPTION
If you insert single fields after fields with the `w50` class, you must set the `clr` class too (depending on the field). Otherwise the field will appear too close to the previous fields and it might cause issues in Contao 4. See also https://community.contao.org/de/showthread.php?66646-caroufredsel-mit-Contao-4-3-7